### PR TITLE
Match increments on a range of months

### DIFF
--- a/cron/months.pl
+++ b/cron/months.pl
@@ -22,7 +22,7 @@
     ## end first single month unit
     # optional second unit (range) or increment
     (?:
-        # range, a literal dash followed by ANOTHER single unit
+        # range, a literal dash followed by ANOTHER single unit (optionally followed by an ignored increment)
         (?:
             [-]
             ## second single month unit
@@ -41,6 +41,11 @@
                 [*]
             )
             ## end second single month unit
+            # optional (ignored) increment, immediately following said range
+            (?:
+                [/]
+                [0-9]+
+            )?
         )
         |
         # OR increment, a literal slash followed by integer increment value
@@ -71,7 +76,7 @@
         ## end first single month unit
         # optional second unit (range) or increment
         (?:
-            # range, a literal dash followed by ANOTHER single unit
+            # range, a literal dash followed by ANOTHER single unit (optionally followed by an ignored increment)
             (?:
                 [-]
                 ## second single month unit
@@ -90,6 +95,11 @@
                     [*]
                 )
                 ## end second single month unit
+                # optional (ignored) increment, immediately following said range
+                (?:
+                    [/]
+                    [0-9]+
+                )?
             )
             |
             # OR increment, a literal slash followed by integer increment value
@@ -125,7 +135,7 @@
 ## end first single month unit
 # optional second unit (range) or increment
 (?:
-    # range, a literal dash followed by ANOTHER single unit
+    # range, a literal dash followed by ANOTHER single unit (optionally followed by an ignored increment)
     (?:
         [-]
         ## second single month unit
@@ -144,6 +154,11 @@
             [*]
         )
         ## end second single month unit
+        # optional (ignored) increment, immediately following said range
+        (?:
+            [/]
+            [0-9]+
+        )?
     )
     |
     # OR increment, a literal slash followed by integer increment value

--- a/main.pl
+++ b/main.pl
@@ -265,7 +265,7 @@ our $expanded = qr`
                     ## end first single month unit
                     # optional second unit (range) or increment
                     (?:
-                        # range, a literal dash followed by ANOTHER single unit
+                        # range, a literal dash followed by ANOTHER single unit (optionally followed by an ignored increment)
                         (?:
                             [-]
                             ## second single month unit
@@ -284,6 +284,11 @@ our $expanded = qr`
                                 [*]
                             )
                             ## end second single month unit
+                            # optional (ignored) increment, immediately following said range
+                            (?:
+                                [/]
+                                [0-9]+
+                            )?
                         )
                         |
                         # OR increment, a literal slash followed by integer increment value
@@ -314,7 +319,7 @@ our $expanded = qr`
                         ## end first single month unit
                         # optional second unit (range) or increment
                         (?:
-                            # range, a literal dash followed by ANOTHER single unit
+                            # range, a literal dash followed by ANOTHER single unit (optionally followed by an ignored increment)
                             (?:
                                 [-]
                                 ## second single month unit
@@ -333,6 +338,11 @@ our $expanded = qr`
                                     [*]
                                 )
                                 ## end second single month unit
+                                # optional (ignored) increment, immediately following said range
+                                (?:
+                                    [/]
+                                    [0-9]+
+                                )?
                             )
                             |
                             # OR increment, a literal slash followed by integer increment value
@@ -627,7 +637,7 @@ our $expanded = qr`
                     ## end first single month unit
                     # optional second unit (range) or increment
                     (?:
-                        # range, a literal dash followed by ANOTHER single unit
+                        # range, a literal dash followed by ANOTHER single unit (optionally followed by an ignored increment)
                         (?:
                             [-]
                             ## second single month unit
@@ -646,6 +656,11 @@ our $expanded = qr`
                                 [*]
                             )
                             ## end second single month unit
+                            # optional (ignored) increment, immediately following said range
+                            (?:
+                                [/]
+                                [0-9]+
+                            )?
                         )
                         |
                         # OR increment, a literal slash followed by integer increment value
@@ -676,7 +691,7 @@ our $expanded = qr`
                         ## end first single month unit
                         # optional second unit (range) or increment
                         (?:
-                            # range, a literal dash followed by ANOTHER single unit
+                            # range, a literal dash followed by ANOTHER single unit (optionally followed by an ignored increment)
                             (?:
                                 [-]
                                 ## second single month unit
@@ -695,6 +710,11 @@ our $expanded = qr`
                                     [*]
                                 )
                                 ## end second single month unit
+                                # optional (ignored) increment, immediately following said range
+                                (?:
+                                    [/]
+                                    [0-9]+
+                                )?
                             )
                             |
                             # OR increment, a literal slash followed by integer increment value
@@ -820,6 +840,6 @@ $
 # (note the /x flag will ignore the leading and trailing newlines regardless)
 our $collapsed = qr`
 
-^(?:rate[(](?:(?:1[ ]+(hour|minute|day))|(?:[0-9]+[ ]+(hours|minutes|days)))[)])|(?:cron[(](?:(?:(?:[0-5]?[0-9])|[*])(?:(?:[-](?:(?:[0-5]?[0-9])|[*]))|(?:[/][0-9]+))?(?:[,](?:(?:[0-5]?[0-9])|[*])(?:(?:[-](?:(?:[0-5]?[0-9])|[*]))|(?:[/][0-9]+))?)*)[ ]+(?:(?:(?:[0-2]?[0-9])|[*])(?:(?:[-](?:(?:[0-2]?[0-9])|[*]))|(?:[/][0-9]+))?(?:[,](?:(?:[0-2]?[0-9])|[*])(?:(?:[-](?:(?:[0-2]?[0-9])|[*]))|(?:[/][0-9]+))?)*)[ ]+(?:(?:[?][ ]+(?:(?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*])(?:(?:[-](?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*]))|(?:[/][0-9]+))?(?:[,](?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*])(?:(?:[-](?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*]))|(?:[/][0-9]+))?)*)[ ]+(?:(?:(?:[1-7]|(?:SUN|MON|TUE|WED|THU|FRI|SAT))[#][0-5])|(?:(?:(?:(?:[1-7]|(?:SUN|MON|TUE|WED|THU|FRI|SAT))L?)|[L*])(?:(?:[-](?:(?:(?:[1-7]|(?:SUN|MON|TUE|WED|THU|FRI|SAT))L?)|[L*]))|(?:[/][0-9]+))?(?:[,](?:(?:(?:[1-7]|(?:SUN|MON|TUE|WED|THU|FRI|SAT))L?)|[L*])(?:(?:[-](?:(?:(?:[1-7]|(?:SUN|MON|TUE|WED|THU|FRI|SAT))L?)|[L*]))|(?:[/][0-9]+))?)*)))|(?:(?:(?:(?:(?:[1-3]?[0-9])W?)|LW|[L*])(?:(?:[-](?:(?:(?:[1-3]?[0-9])W?)|LW|[L*]))|(?:[/][0-9]+))?(?:[,](?:(?:(?:[1-3]?[0-9])W?)|LW|[L*])(?:(?:[-](?:(?:(?:[1-3]?[0-9])W?)|LW|[L*]))|(?:[/][0-9]+))?)*)[ ]+(?:(?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*])(?:(?:[-](?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*]))|(?:[/][0-9]+))?(?:[,](?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*])(?:(?:[-](?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*]))|(?:[/][0-9]+))?)*)[ ]+[?]))[ ]+(?:(?:(?:[12][0-9]{3})|[*])(?:(?:[-](?:(?:[12][0-9]{3})|[*]))|(?:[/][0-9]+))?(?:[,](?:(?:[12][0-9]{3})|[*])(?:(?:[-](?:(?:[12][0-9]{3})|[*]))|(?:[/][0-9]+))?)*)[)])$
+^(?:rate[(](?:(?:1[ ]+(hour|minute|day))|(?:[0-9]+[ ]+(hours|minutes|days)))[)])|(?:cron[(](?:(?:(?:[0-5]?[0-9])|[*])(?:(?:[-](?:(?:[0-5]?[0-9])|[*]))|(?:[/][0-9]+))?(?:[,](?:(?:[0-5]?[0-9])|[*])(?:(?:[-](?:(?:[0-5]?[0-9])|[*]))|(?:[/][0-9]+))?)*)[ ]+(?:(?:(?:[0-2]?[0-9])|[*])(?:(?:[-](?:(?:[0-2]?[0-9])|[*]))|(?:[/][0-9]+))?(?:[,](?:(?:[0-2]?[0-9])|[*])(?:(?:[-](?:(?:[0-2]?[0-9])|[*]))|(?:[/][0-9]+))?)*)[ ]+(?:(?:[?][ ]+(?:(?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*])(?:(?:[-](?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*])(?:[/][0-9]+)?)|(?:[/][0-9]+))?(?:[,](?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*])(?:(?:[-](?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*])(?:[/][0-9]+)?)|(?:[/][0-9]+))?)*)[ ]+(?:(?:(?:[1-7]|(?:SUN|MON|TUE|WED|THU|FRI|SAT))[#][0-5])|(?:(?:(?:(?:[1-7]|(?:SUN|MON|TUE|WED|THU|FRI|SAT))L?)|[L*])(?:(?:[-](?:(?:(?:[1-7]|(?:SUN|MON|TUE|WED|THU|FRI|SAT))L?)|[L*]))|(?:[/][0-9]+))?(?:[,](?:(?:(?:[1-7]|(?:SUN|MON|TUE|WED|THU|FRI|SAT))L?)|[L*])(?:(?:[-](?:(?:(?:[1-7]|(?:SUN|MON|TUE|WED|THU|FRI|SAT))L?)|[L*]))|(?:[/][0-9]+))?)*)))|(?:(?:(?:(?:(?:[1-3]?[0-9])W?)|LW|[L*])(?:(?:[-](?:(?:(?:[1-3]?[0-9])W?)|LW|[L*]))|(?:[/][0-9]+))?(?:[,](?:(?:(?:[1-3]?[0-9])W?)|LW|[L*])(?:(?:[-](?:(?:(?:[1-3]?[0-9])W?)|LW|[L*]))|(?:[/][0-9]+))?)*)[ ]+(?:(?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*])(?:(?:[-](?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*])(?:[/][0-9]+)?)|(?:[/][0-9]+))?(?:[,](?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*])(?:(?:[-](?:(?:[1]?[0-9])|(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|[*])(?:[/][0-9]+)?)|(?:[/][0-9]+))?)*)[ ]+[?]))[ ]+(?:(?:(?:[12][0-9]{3})|[*])(?:(?:[-](?:(?:[12][0-9]{3})|[*]))|(?:[/][0-9]+))?(?:[,](?:(?:[12][0-9]{3})|[*])(?:(?:[-](?:(?:[12][0-9]{3})|[*]))|(?:[/][0-9]+))?)*)[)])$
 
 `x;

--- a/tests/positives.txt
+++ b/tests/positives.txt
@@ -19,3 +19,4 @@ cron(0 23-4 L * ? *)	First minute of every hour between 11am and 4pm on last day
 cron(0 0 L 6 ? 2020-2040)	Midnight (UTC+0) on last day of June, from 2020 to 2040
 cron(0 0 ? * SUN,TUE,THU *)	Midnight (UTC+0) every Sunday, Tuesday and Thursday
 cron(0 0 1 1 ? 2020/3)	Midnight (UTC+0) on first day of every month, every 3 years starting from 2020
+cron(0 0 1 JAN-MAR/2 ? *)	Midnight (UTC+0) on first day of month, January through March, silently ignoring increment of month


### PR DESCRIPTION
The AWS scheduler appears to allow a month field of `${startMonth}-{endMonth}/${increment}` while effectively ignoring the increment in favor of the range.

This should match such cases, as the example of `JAN-MAR/2` outlined in issue #1